### PR TITLE
Port the script to Python 3.6 + add tests + Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: xenial
+language: python
+python:
+- '3.6'
+install:
+- pip install pipenv
+- pipenv install --dev
+script:
+- pipenv run pytest

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,8 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+pytest = "*"
+pytest-mock = "*"
 
 [packages]
 numpy = "*"
@@ -11,4 +13,4 @@ matplotlib = "*"
 scipy = "*"
 
 [requires]
-python_version = "2.7"
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d1fc109aa4aa27b2d36b5073438cab186b5b7d1cb784ce099e2c97d2e8dc1e3a"
+            "sha256": "5159d1f6f7ca5a542896c526872064c71d56fd719b49c0d3c858f210523fa6bc"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "2.7"
+            "python_version": "3.6"
         },
         "sources": [
             {
@@ -16,13 +16,6 @@
         ]
     },
     "default": {
-        "backports.functools-lru-cache": {
-            "hashes": [
-                "sha256:9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a",
-                "sha256:f0b0e4eba956de51238e17573b7087e852dfe9854afd2e9c873f73fc0ca0a6dd"
-            ],
-            "version": "==1.5"
-        },
         "cycler": {
             "hashes": [
                 "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d",
@@ -65,31 +58,22 @@
         },
         "matplotlib": {
             "hashes": [
-                "sha256:029620799e581802961ac1dcff5cb5d3ee2f602e0db9c0f202a90495b37d2126",
-                "sha256:2308f67e085735ed580fcace652339cb517f059cdc9ee8a418c1b55746dbffcb",
-                "sha256:280aebaec25575e35bf7d1b3ebb2d8ae7e839edb5a403f1a121b7271744b1ef9",
-                "sha256:295099acb5a8a1148d1b4693ad1a93479a20836cd8b7eb38183a98c84cdcb2f1",
-                "sha256:75d44c55eb87af653afc3d0a37ab62ab4784c752be0e7c96622713d88ed57e64",
-                "sha256:95d9d7c2d7f0c7a4317acbcf1a81efa0a2ce5cb5ddfad606ae4c25a783431f0a",
-                "sha256:9703ffc3e7e369f3ab31d0032719710876cb341eb618e1a8a54447e1946a9f0a",
-                "sha256:9ff80541d5676207c6e829632b28e22d9875ecaae54eab7a7f8fd82a6552e5e9",
-                "sha256:a6a04ebd81b3183e7882c9047a9514b7f547b2bae5e4f61a02eaaa6b446bde54",
-                "sha256:b22b0d3b8d8f769c6ac559f6761878d660bd23d67b36430f07161caf1505c29c",
-                "sha256:b464d598e36e13f7d798443805f2ba6b4af3d26fc1652c51c77a7847cf665813",
-                "sha256:c0fa162920185d5d74e6fdf52c1f8cca0fbf897025a9dd81e030cf08a915865a",
-                "sha256:c452b7aff0a9e4612670a4590e6efc30929dad620a121d423c8f3d0bd93715e2",
-                "sha256:c90fc796e97815ea3bbbdea63c1e4edf75336361a49b945fdbc2aff1c76008c6",
-                "sha256:cc1d376963ea9c97338582f3f9d64757c51e71cf2655efe363a3f2414d84aac2",
-                "sha256:d3f5dfaa345539599308bd83826db242e424e3f4e9657952f8738ce1b5b90e8a",
-                "sha256:d9e80ba0ffdb0daacaf49e561474d5c5c153d6db853478cf90c8cba5ed8b72b1",
-                "sha256:daac44fc77cf36ff01953e2acc57a843fb1f6572eb5bf0af10a2930fa7407715",
-                "sha256:de43c85335d71094a254e8538719752e30db3305005dae8dcb3097b72587ed07",
-                "sha256:e4621af28a2444f93b5b6d3d60f54767df8ac6daa510a98f68c34377cb474869",
-                "sha256:f3755a52aae7fb640f5f57b7b63eb5d65688c84931d7833dbc7d03959cd4f8ce",
-                "sha256:f99c43df8ed2b9d1c95a042f3cacf017f9690092feba0b4292eaa6713f92de97"
+                "sha256:1ae6549976b6ceb6ee426272a28c0fc9715b3e3669694d560c8f661c5b39e2c5",
+                "sha256:4d4250bf508dd07cca3b43888097f873cadb66eec6ac63dbbfb798798ec07af2",
+                "sha256:53af2e01d7f1700ed2b64a9091bc865360c9c4032f625451c4589a826854c787",
+                "sha256:63e498067d32d627111cd1162cae1621f1221f9d4c6a9745dd7233f29de581b6",
+                "sha256:7169a34971e398dd58e87e173f97366fd88a3fa80852704530433eb224a8ca57",
+                "sha256:91c54d6bb9eeaaff965656c5ea6cbdcbf780bad8462ac99b30b451548194746f",
+                "sha256:aeef177647bb3fccfe09065481989d7dfc5ac59e9367d6a00a3481062cf651e4",
+                "sha256:cf8ae10559a78aee0409ede1e9d4fda03895433eeafe609dd9ed67e45f552db0",
+                "sha256:d51d0889d1c4d51c51a9822265c0494ea3e70a52bdd88358e0863daca46fa23a",
+                "sha256:de5ccd3500247f85fe4f9fad90f80a8bd397e4f110a4c33fabf95f07403e8372",
+                "sha256:e1d33589e32f482d0a7d1957bf473d43341115d40d33f578dad44432e47df7b7",
+                "sha256:e8d1939262aa6b36d0c51f50a50a43a04b9618d20db31e6c0192b1463067aeef",
+                "sha256:e918d51b1fda82a65fdf52d2f3914b2246481cc2a9cd10e223e6be6078916ff3"
             ],
             "index": "pypi",
-            "version": "==2.2.4"
+            "version": "==3.0.3"
         },
         "numpy": {
             "hashes": [
@@ -134,13 +118,6 @@
             ],
             "version": "==2.8.0"
         },
-        "pytz": {
-            "hashes": [
-                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
-                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
-            ],
-            "version": "==2019.1"
-        },
         "scipy": {
             "hashes": [
                 "sha256:014cb900c003b5ac81a53f2403294e8ecf37aedc315b59a6b9370dce0aa7627a",
@@ -181,14 +158,67 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
-        },
-        "subprocess32": {
-            "hashes": [
-                "sha256:24a7f627ef7a5695138601b665057ad131fa26e80d49d5ffa6b4fdb2357a80d3",
-                "sha256:6bc82992316eef3ccff319b5033809801c0c3372709c5f6985299c88ac7225c3"
-            ],
-            "version": "==3.5.3"
         }
     },
-    "develop": {}
+    "develop": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "version": "==1.3.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
+                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
+            ],
+            "markers": "python_version > '2.7'",
+            "version": "==7.0.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
+                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
+            ],
+            "version": "==0.9.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+            ],
+            "version": "==1.8.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:3773f4c235918987d51daf1db66d51c99fac654c81d6f2f709a046ab446d5e5d",
+                "sha256:b7802283b70ca24d7119b32915efa7c409982f59913c1a6c0640aacf118b95f5"
+            ],
+            "index": "pypi",
+            "version": "==4.4.1"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:43ce4e9dd5074993e7c021bb1c22cbb5363e612a2b5a76bc6d956775b10758b7",
+                "sha256:5bf5771b1db93beac965a7347dc81c675ec4090cb841e49d9d34637a25c30568"
+            ],
+            "index": "pypi",
+            "version": "==1.10.4"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        }
+    }
 }

--- a/parser.py
+++ b/parser.py
@@ -11,8 +11,6 @@ IMPROVED = "improved"
 
 class Parser:
     def __init__(self, mode):
-        self.users_number = 0
-        self.movies_number = 0
         file_mode = IMPROVED if mode == IMPROVED else BASELINE
         self.movies_file = DIR + file_mode + "." + MOVIE_NAMES
         self.data_file = DIR + file_mode + "." + DATA
@@ -24,16 +22,17 @@ class Parser:
     # for *.training and *.test files (u, m, r)
     def data_parse(self, filename):
         data = []
-        with open(filename, "rb") as csv_file:
+        with open(filename, "r") as csv_file:
             f_reader = csv.reader(csv_file, delimiter=",")
             for row in f_reader:
                 data.append([int(row[0]), int(row[1]), int(row[2])])
-        self.users_number = max(map(lambda x: x[0], data))
         csv_file.close()
         return data
 
     def get_umr_matrix(self, raw_data):
-        matrix = np.zeros((self.users_number, self.movies_number))
+        users_number = max(map(lambda x: x[0], raw_data))
+        movies_number = len(self.titles)
+        matrix = np.zeros((users_number, movies_number))
         for row in raw_data:
             matrix[row[0] - 1, row[1] - 1] = row[2]
         return matrix
@@ -41,10 +40,9 @@ class Parser:
     # for *.moviename files (m, title)
     def moviename_parse(self, filename):
         data = []
-        with open(filename, "rb") as csv_file:
+        with open(filename, "r") as csv_file:
             f_reader = csv.reader(csv_file, delimiter=";")
             for row in f_reader:
                 data.append(row[1])
-                self.movies_number += 1
         csv_file.close()
         return data

--- a/test_predictor.py
+++ b/test_predictor.py
@@ -24,7 +24,7 @@ def mock_parser_reading_files(mocker):
 
 
 @pytest.mark.parametrize("mode", ["baseline", "improved"])
-def test_rmse_calculated(mode, *_):
+def test_rmse_calculated(mode):
     parser = Parser(mode)
     predictor = Predictor(mode, parser.training_matrix, parser.test_set)
     assert predictor.rmse_test > 0.0

--- a/test_predictor.py
+++ b/test_predictor.py
@@ -1,0 +1,33 @@
+import pytest
+
+from parser import Parser
+from predictor import Predictor
+
+test_data = [
+    [1, 1, 1],
+    [2, 1, 3],
+    [2, 2, 4],
+    [3, 1, 1],
+    [3, 2, 5],
+]
+
+movie_titles = [
+    [1, "Shrek"],
+    [2, "Matrix"]
+]
+
+
+@pytest.fixture(autouse=True)
+def mock_parser_reading_files(mocker):
+    mocker.patch("parser.Parser.data_parse", return_value=test_data)
+    mocker.patch("parser.Parser.moviename_parse", return_value=movie_titles)
+
+
+@pytest.mark.parametrize("mode", ["baseline", "improved"])
+def test_rmse_calculated(mode, *_):
+    parser = Parser(mode)
+    predictor = Predictor(mode, parser.training_matrix, parser.test_set)
+    assert predictor.rmse_test > 0.0
+    assert predictor.rmse_training > 0.0
+    if mode == "improved":
+        assert predictor.rmse_test_improved > 0.0


### PR DESCRIPTION
Summary of changes:
- In order to port the script to Python 3.6 "rb" mode of opening a CSV file needed to be changed to "r".
- The only feasible way to write any test for the script is to mock methods reading data files from disk. In order to accomplish that, properties `users_number` and `movies_number` were deleted and replaced with local variables (they were not really useful as properties...). This trend needs to continue, as properties are overused in the code.
- Currently the new test checks whether the RMSE is calculated at all, it doesn't check for correctness. It serves the purpose of a "smoke" test, so that further refactoring can be done without the time-consuming execution of the script on real data with every little change. More well-fitted tests are to come.